### PR TITLE
Dockerization.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Then, you can start the server with
 ### Daemon Run
 
 ```
-docker run -d -p 9443:9443 -e LICENSE=accept --name gameon-player gameon-player
+docker run -d -p 9443:9443 -e LICENSE=accept -e DOCKER_CONCIERGE_URL=http://game-on.org:9081/concierge --name gameon-player gameon-player
 ```
 
 ### Stop
@@ -79,7 +79,7 @@ docker stop gameon-player ; docker rm gameon-player
 ### Restart Daemon
 
 ```
-docker run -d -p 9443:9443 -e LICENSE=accept --name gameon-player gameon-player ; docker stop gameon-player ; docker rm gameon-player
+docker stop gameon-player ; docker rm gameon-player; docker run -d -p 9443:9443 -e LICENSE=accept --name gameon-player gameon-player
 ```
 
 

--- a/player-app/build.gradle
+++ b/player-app/build.gradle
@@ -37,6 +37,15 @@ dependencies {
     
 }
 
+task exportLibs(type: Copy) {
+  into "$buildDir/libs/"
+  from configurations.runtime
+  include "*mongo*.jar"
+}
+
+build.dependsOn(exportLibs)
+build.dependsOn(bowerInstall)
+
 // Set the Eclipse facets to use 3.1 of the Dynamic Web Module which requires Java 1.7 (at least)
 // Also include JAX-RS and javascript
 eclipse.wtp.facet {

--- a/player-wlpcfg/Dockerfile
+++ b/player-wlpcfg/Dockerfile
@@ -2,9 +2,9 @@ FROM websphere-liberty:latest
 
 MAINTAINER Ben Smith
 
-COPY ./servers/gameon-player/* /opt/ibm/wlp/usr/servers/defaultServer/
-COPY ./servers/gameon-player/resources/security/* /opt/ibm/wlp/usr/servers/defaultServer/resources/security/
-COPY ./servers/gameon-player/apps/player-app-1.0.war /opt/ibm/wlp/usr/servers/defaultServer/apps/player-app.war
+ADD ./servers/gameon-player /opt/ibm/wlp/usr/servers/defaultServer/
+RUN rm /opt/ibm/wlp/usr/servers/defaultServer/server.env
+COPY ./oauth-credentials.xml /opt/ibm/wlp/usr/servers/defaultServer/configDropins/overrides/
 
 RUN /opt/ibm/wlp/bin/featureManager install mongodb-2.0 --acceptLicense
 

--- a/player-wlpcfg/build.gradle
+++ b/player-wlpcfg/build.gradle
@@ -11,9 +11,15 @@ buildscript {
 }
 
 
-task copyTask(type: Copy) {
+task copyWAR(type: Copy) {
     from '../player-app/build/libs/player-app-1.0.war'
     into 'servers/gameon-player/apps/'
+    rename("player-app-1.0.war", "player-app.war")
+}
+
+task copyMongo(type: Copy) {
+    from '../player-app/build/libs/mongo-java-driver-2.12.3.jar'
+    into 'servers/gameon-player/lib/'
 }
 
 apply plugin: 'com.bmuschko.docker-remote-api'
@@ -24,7 +30,7 @@ docker {
     url = 'unix:///var/run/docker.sock'
 }
 
-task buildImage(type: DockerBuildImage, dependsOn: 'copyTask') {
+task buildImage(type: DockerBuildImage, dependsOn: ['copyWAR', 'copyMongo']) {
 	inputDir = file('.')
     tag = 'gameon-player'
 }

--- a/player-wlpcfg/oauth-credentials.example
+++ b/player-wlpcfg/oauth-credentials.example
@@ -1,0 +1,9 @@
+<server>
+	<!-- Twitter Application info.. -->
+	<jndiEntry jndiName="twitterOAuthConsumerKey" value=""/>
+	<jndiEntry jndiName="twitterOAuthConsumerSecret" value=""/>
+	
+	<!-- Facebook Application info.. -->
+	<jndiEntry jndiName="facebookAppID" value=""/>
+	<jndiEntry jndiName="facebookAppSecret" value=""/>
+</server> 


### PR DESCRIPTION
Mongo and app WAR are copied as separate tasks in gradle, and buildImage depends on both.
Added oauth-credentials example XML that you personalize and is then copied in as override to Dockerfile.
Dockerfile fixed to copy in new WAR file to drive mongo.
Added bits to README to indicate specifying the CONCIERGE_URL, since you have to.