### PR TITLE
Controlling the environment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Or, if you don't have gradle, then:
 ### Interactive Run
 
 ```
-docker run -it -p 9443:9443 -e LICENSE=accept gameon-player bash
+docker run -it -p 9443:9443 --env-file=./dockerrc --name gameon-player gameon-player bash
 ```
 
 Then, you can start the server with 
@@ -67,7 +67,7 @@ Then, you can start the server with
 ### Daemon Run
 
 ```
-docker run -d -p 9443:9443 -e LICENSE=accept -e DOCKER_CONCIERGE_URL=http://game-on.org:9081/concierge --name gameon-player gameon-player
+docker run -d -p 9443:9443 --env-file=./dockerrc --name gameon-player gameon-player
 ```
 
 ### Stop
@@ -79,7 +79,7 @@ docker stop gameon-player ; docker rm gameon-player
 ### Restart Daemon
 
 ```
-docker stop gameon-player ; docker rm gameon-player; docker run -d -p 9443:9443 -e LICENSE=accept --name gameon-player gameon-player
+docker stop gameon-player ; docker rm gameon-player; docker run -d -p 9443:9443 --env-file=./dockerrc --name gameon-player gameon-player
 ```
 
 

--- a/player-wlpcfg/.gitignore
+++ b/player-wlpcfg/.gitignore
@@ -1,11 +1,14 @@
 /.settings/
 /.project
 .*.swp
+oauth-credentials.xml
+dockerrc
 /servers/*/apps
 /servers/*/logs
 /servers/*/resources/security/key.jks
 /servers/*/resources/security/ltpa.keys
 /servers/*/workarea
+/servers/*/lib
 /servers/.pid
 /build/
 /servers/.classCache

--- a/player-wlpcfg/dockerrc.example
+++ b/player-wlpcfg/dockerrc.example
@@ -2,3 +2,4 @@ WLP_SKIP_MAXPERMSIZE=true
 CONCIERGE_URL=http://localhost:9081/concierge
 MONGO_HOST=localhost
 MONGO_PORT=27017
+LICENSE=accept

--- a/player-wlpcfg/servers/gameon-player/server.xml
+++ b/player-wlpcfg/servers/gameon-player/server.xml
@@ -23,7 +23,7 @@
     <file name="lib/mongo-java-driver-2.12.3.jar"/>
   </library>
   
-  <mongo id="mongo" libraryRef="MongoLib"/>
+  <mongo id="mongo" libraryRef="MongoLib" hostNames="${env.MONGO_HOST}" ports="${env.MONGO_PORT}" />
   <mongoDB databaseName="playerDB" jndiName="mongo/playerDB" mongoRef="mongo"/>
   
   <!-- To access this server from a remote client add a host attribute to 


### PR DESCRIPTION
- Add oauth-credentials.xml to gitignore.
- Show a dockerrc.example to indicate how variables can be set within
Docker.
- Ignore dockerrc (as it would be the live copy)
- Use environment variables for MongoDB Host and Port, but add them to
server.env so local should not be broken.
- Update the doc to show how to use --env-file