### PR TITLE
Fix the CORS issue with a servlet filter.

### DIFF
--- a/player-app/src/main/java/net/wasdev/gameon/CORSFilter.java
+++ b/player-app/src/main/java/net/wasdev/gameon/CORSFilter.java
@@ -1,0 +1,24 @@
+package net.wasdev.gameon;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
+
+public class CORSFilter implements Filter {
+
+	public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+	     HttpServletResponse sresponse = (HttpServletResponse) response;
+	     sresponse.setHeader("Access-Control-Allow-Origin", "*");
+	     chain.doFilter(request, response);
+	 }
+	 
+	     public void init(FilterConfig filterConfig) {}
+	 
+	     public void destroy() {}
+}

--- a/player-app/src/main/webapp/WEB-INF/web.xml
+++ b/player-app/src/main/webapp/WEB-INF/web.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<web-app xmlns="http://java.sun.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd" version="2.5">
+    <filter>
+         <filter-name>CORS</filter-name>
+         <filter-class>net.wasdev.gameon.CORSFilter</filter-class>
+     </filter>
+     <filter-mapping>
+         <filter-name>CORS</filter-name>
+         <url-pattern>/*</url-pattern>
+     </filter-mapping>
+ </web-app>


### PR DESCRIPTION
When running locally, player service runs on 9443 and webapp runs on 3000.  This creates issues with CORS, because `localhost:9443` is not counted as the same host as `localhost:3000`.  This commit fixes that problem by introducing a `CORSFilter` class that allows us to set the `Access-Control-Allow-Origin` header for all responses back from the player service.