### PR TITLE
Logging to Logmet

### DIFF
--- a/player-wlpcfg/Dockerfile
+++ b/player-wlpcfg/Dockerfile
@@ -2,10 +2,15 @@ FROM websphere-liberty:latest
 
 MAINTAINER Ben Smith
 
-ADD ./servers/gameon-player /opt/ibm/wlp/usr/servers/defaultServer/
-RUN rm /opt/ibm/wlp/usr/servers/defaultServer/server.env
+ADD https://download.elastic.co/logstash-forwarder/binaries/logstash-forwarder_linux_amd64 /opt/forwarder
+ADD http://game-on.org:8081/logstashneeds.tar /opt/logstashneeds.tar
 
-RUN /opt/ibm/wlp/bin/featureManager install mongodb-2.0 --acceptLicense
+ADD ./servers/gameon-player /opt/ibm/wlp/usr/servers/defaultServer/
+RUN rm /opt/ibm/wlp/usr/servers/defaultServer/server.env ; \
+ 	/opt/ibm/wlp/bin/featureManager install mongodb-2.0 --acceptLicense ; \
+ 	cd /opt ; chmod +x ./forwarder ; tar xvzf logstashneeds.tar ; rm logstashneeds.tar
+ 	
+COPY ./forwarder.conf /opt/forwarder.conf 	
 
 COPY ./startup.sh /opt/startup.sh
 

--- a/player-wlpcfg/build.gradle
+++ b/player-wlpcfg/build.gradle
@@ -55,6 +55,7 @@ task createNewContainer(type: DockerCreateContainer) {
 			"CONCIERGE_URL=" + System.getenv('CONCIERGE_URL'),
 			"MONGO_HOST=" + System.getenv('MONGO_HOST'),
 			"MONGO_PORT=" + System.getenv('MONGO_PORT'),
+			"LOGGING_DOCKER_HOST=" + System.getenv("LOGGING_DOCKER_HOST"),
 			"TWITTER_CONSUMER_KEY=" + System.getenv('TWITTER_CONSUMER_KEY'),
 			"TWITTER_CONSUMER_SECRET=" + System.getenv('TWITTER_CONSUMER_SECRET'),
 			"FACEBOOK_APP_ID=" + System.getenv('FACEBOOK_APP_ID'),

--- a/player-wlpcfg/forwarder.conf
+++ b/player-wlpcfg/forwarder.conf
@@ -1,0 +1,37 @@
+{
+  # The network section covers network configuration :)
+  "network": {
+    # A list of downstream servers listening for our messages.
+    # logstash-forwarder will pick one at random and only switch if
+    # the selected one appears to be dead or unresponsive
+    "servers": [ "PLACEHOLDER_LOGHOST:5043" ],
+
+    # The path to your client ssl certificate (optional)
+    "ssl certificate": "./logstash-forwarder.crt",
+    # The path to your client ssl key (optional)
+    "ssl key": "./logstash-forwarder.key",
+
+    # The path to your trusted ssl CA file. This is used
+    # to authenticate your downstream server.
+    "ssl ca": "./logstash-forwarder.crt",
+
+    # Network timeout in seconds. This is most important for
+    # logstash-forwarder determining whether to stop waiting for an
+    # acknowledgement from the downstream server. If an timeout is reached,
+    # logstash-forwarder will assume the connection or server is bad and
+    # will connect to a server chosen at random from the servers list.
+    "timeout": 15
+  },
+
+  # The list of files configurations
+  "files": [
+    {
+      "paths": [
+        "/opt/ibm/wlp/usr/servers/defaultServer/logs/*.log"
+      ],
+      "fields": { "type": "liberty",
+      			  "source": "player"
+      			}
+    }
+  ]
+}

--- a/player-wlpcfg/startup.sh
+++ b/player-wlpcfg/startup.sh
@@ -1,3 +1,5 @@
 #!/bin/bash
-/opt/ibm/wlp/bin/server run defaultServer
-
+/opt/ibm/wlp/bin/server start defaultServer
+echo Running Logstash Forwarder...
+sed -i s/PLACEHOLDER_LOGHOST/$LOGGING_DOCKER_HOST/g /opt/forwarder.conf
+cd /opt ; ./forwarder --config ./forwarder.conf


### PR DESCRIPTION
Incorporate the Logstash Forwarder, which will also run in this Liberty container, and will forward everything in `/opt/wlp/usr/servers/defaultServer/logs` over to our Logstash, which will then have to grok the Liberty logs and push it up to Logmet.