### PR TITLE
Enable the creation of a liberty-served SSL certificate

### DIFF
--- a/player-wlpcfg/build.gradle
+++ b/player-wlpcfg/build.gradle
@@ -45,6 +45,10 @@ if (null != System.getenv("LOGSTASH_ENDPOINT"))
 	determinedEnvironment << "LOGSTASH_CERT=" + System.getenv("LOGSTASH_CERT")
 }
 
+if (null != System.getenv("SSL_CERT"))
+{
+	determinedEnvironment << "SSL_CERT=" + System.getenv("SSL_CERT")
+}
 
 task copyWAR(type: Copy) {
     from '../player-app/build/libs/player-app-1.0.war'

--- a/player-wlpcfg/startup.sh
+++ b/player-wlpcfg/startup.sh
@@ -1,5 +1,16 @@
 #!/bin/bash
 
+if [ "$SSL_CERT" != "" ]; then
+  echo Found an SSL cert to use.
+  cd /opt/ibm/wlp/usr/servers/defaultServer/resources/
+  echo -e $SSL_CERT > cert.pem
+  openssl pkcs12 -passin pass:keystore -passout pass:keystore -export -out cert.pkcs12 -in cert.pem
+  keytool -import -v -trustcacerts -alias default -file cert.pem -storepass truststore -keypass keystore -noprompt -keystore security/truststore.jks
+  keytool -genkey -storepass testOnlyKeystore -keypass wefwef -keyalg RSA -alias endeca -keystore security/key.jks -dname CN=rsssl,OU=unknown,O=unknown,L=unknown,ST=unknown,C=CA
+  keytool -delete -storepass testOnlyKeystore -alias endeca -keystore security/key.jks
+  keytool -v -importkeystore -srcalias 1 -alias 1 -destalias default -noprompt -srcstorepass keystore -deststorepass testOnlyKeystore -srckeypass keystore -destkeypass testOnlyKeystore -srckeystore cert.pkcs12 -srcstoretype PKCS12 -destkeystore security/key.jks -deststoretype JKS
+fi
+
 if [ "$LOGSTASH_ENDPOINT" != "" ]; then
   /opt/ibm/wlp/bin/server start defaultServer
   echo Starting the logstash forwarder...


### PR DESCRIPTION
If the variable `SSL_CERT` exists, then use `keytool` to add a PKCS12 version of that certificate to the Java Keystore that Liberty uses so that Liberty can then become game-on.org.