### PR TITLE
Add Jackson Providers with narrower MediaTypes, revert back to jaxrs …

### DIFF
--- a/player-app/src/main/java/net/wasdev/gameon/player/AllPlayersResource.java
+++ b/player-app/src/main/java/net/wasdev/gameon/player/AllPlayersResource.java
@@ -59,15 +59,12 @@ public class AllPlayersResource {
 
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getAllPlayers() throws IOException {
+    public List<Player> getAllPlayers() throws IOException {
 
         ViewQuery q = new ViewQuery().allDocs().includeDocs(true);
-        List<Player> results = db.queryView(q, Player.class);
-               
-        ObjectMapper om = new ObjectMapper();
-        String player = om.writeValueAsString(results);  
+        List<Player> results = db.queryView(q, Player.class);  
         
-        return Response.ok(player,MediaType.APPLICATION_JSON).build();
+        return results;
     }
 
     @POST

--- a/player-app/src/main/java/net/wasdev/gameon/player/JaxbJsonProvider.java
+++ b/player-app/src/main/java/net/wasdev/gameon/player/JaxbJsonProvider.java
@@ -1,0 +1,15 @@
+package net.wasdev.gameon.player;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
+
+@Provider
+@Consumes(MediaType.APPLICATION_JSON) 
+@Produces(MediaType.APPLICATION_JSON)
+public class JaxbJsonProvider extends JacksonJaxbJsonProvider {
+
+}

--- a/player-app/src/main/java/net/wasdev/gameon/player/JsonProvider.java
+++ b/player-app/src/main/java/net/wasdev/gameon/player/JsonProvider.java
@@ -1,0 +1,15 @@
+package net.wasdev.gameon.player;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+
+@Provider
+@Consumes(MediaType.APPLICATION_JSON) 
+@Produces(MediaType.APPLICATION_JSON)
+public class JsonProvider extends JacksonJsonProvider {
+
+}

--- a/player-app/src/main/java/net/wasdev/gameon/player/PlayerApplication.java
+++ b/player-app/src/main/java/net/wasdev/gameon/player/PlayerApplication.java
@@ -29,8 +29,18 @@ public class PlayerApplication extends Application {
             Arrays.asList(new Class<?>[] { AllPlayersResource.class, PlayerResource.class, Player.class,
                     PlayerNotFoundException.class, RequestNotAllowedForThisIDException.class }));
 
+    public final static Set<Object> singletons = new HashSet<Object>( 
+            Arrays.asList(new Object[] {new JsonProvider(), new JaxbJsonProvider() } ));
+    
     @Override
     public Set<Class<?>> getClasses() {
         return playerJaxRSClasses;
     }
+
+    @Override
+    public Set<Object> getSingletons() {
+        return singletons;
+    }
+    
+    
 }

--- a/player-app/src/main/java/net/wasdev/gameon/player/PlayerResource.java
+++ b/player-app/src/main/java/net/wasdev/gameon/player/PlayerResource.java
@@ -65,7 +65,7 @@ public class PlayerResource {
     
     @GET
     @Produces(MediaType.APPLICATION_JSON)
-    public Response getPlayerInformation(@PathParam("id") String id) throws IOException {
+    public Player getPlayerInformation(@PathParam("id") String id) throws IOException {
         
         // set by the auth filter.
         String authId = (String) httpRequest.getAttribute("player.id");
@@ -76,12 +76,8 @@ public class PlayerResource {
         }
         
         if(db.contains(id)){
-            Player p = db.get(Player.class, id);   
-            
-            ObjectMapper om = new ObjectMapper();
-            String player = om.writeValueAsString(p);  
-            
-            return Response.ok(player,MediaType.APPLICATION_JSON).build();
+            Player p = db.get(Player.class, id);             
+            return p ; 
         }else{
             throw new PlayerNotFoundException("Id not known");
         }
@@ -105,9 +101,7 @@ public class PlayerResource {
                 throw new PlayerNotFoundException("Id not known");
             }
         }
-        
-
-        
+              
         db.update(newPlayer);
 
         return Response.status(204).build();


### PR DESCRIPTION
…ser/deser

Depends upon change pending over in webapp.

After understanding why my @JSONIgnores were being ignored.. the solution is apparently to add your own json providers with a narrower media type than MediaType.WILDCARD .. which is why the ones in the jackson provider jar were being ignored. 

Once that's done, then ser/deser is correctly honoring the annotations. However this then has a knock-on effect that the id field in the player record becomes _id rather than id ..  webapp has a pending change to accommodate that.