### PR TITLE
Move jwt to headers

### DIFF
--- a/player-app/src/main/java/net/wasdev/gameon/auth/JWT.java
+++ b/player-app/src/main/java/net/wasdev/gameon/auth/JWT.java
@@ -17,11 +17,13 @@ package net.wasdev.gameon.auth;
 
 import java.security.Key;
 import java.security.cert.Certificate;
+import java.util.logging.Level;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
+import net.wasdev.gameon.player.Log;
 
 /**
  * Common class for handling JSON Web Tokens
@@ -46,8 +48,6 @@ public class JWT {
     
     // the authentication steps that are performed on an incoming request
     public enum AuthenticationState {
-        UNKNOWN,                        // starting state
-        hasJWTParam, hasJWTHeader, isJWTValid, 
         PASSED, ACCESS_DENIED           // end state
     }
     
@@ -80,12 +80,10 @@ public class JWT {
                     jwtValid = true;
                     code = FailureCode.NONE;
                 } catch (io.jsonwebtoken.SignatureException e) {
-                    // thrown if the signature on id_token cannot be verified.
-                    System.out.println("JWT did NOT validate ok, bad signature.");
+                    Log.log(Level.WARNING, this, "JWT did NOT validate ok, bad signature.");
                     code = FailureCode.BAD_SIGNATURE;
                 } catch (ExpiredJwtException e) {
-                    // thrown if the jwt had expired.
-                    System.out.println("JWT did NOT validate ok, jwt had expired");
+                    Log.log(Level.WARNING, this, "JWT did NOT validate ok, jwt had expired");
                     code = FailureCode.EXPIRED;
                 }
                 state = !jwtValid ? AuthenticationState.ACCESS_DENIED : AuthenticationState.PASSED;

--- a/player-app/src/main/java/net/wasdev/gameon/auth/JWT.java
+++ b/player-app/src/main/java/net/wasdev/gameon/auth/JWT.java
@@ -1,0 +1,119 @@
+/*******************************************************************************
+ * Copyright (c) 2016 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.gameon.auth;
+
+import java.security.Key;
+import java.security.cert.Certificate;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+
+/**
+ * Common class for handling JSON Web Tokens
+ * 
+ * @author marknsweep
+ *
+ */
+
+public class JWT {
+    private final AuthenticationState state;
+    private FailureCode code;
+    private String token = null;
+    private Jws<Claims> jwt = null;
+
+    public JWT(Certificate cert, String... sources) {
+        state = processSources(cert.getPublicKey(), sources);
+    }
+    
+    public JWT(Key key, String... sources) {
+        state = processSources(key, sources);
+    }
+    
+    // the authentication steps that are performed on an incoming request
+    public enum AuthenticationState {
+        UNKNOWN,                        // starting state
+        hasJWTParam, hasJWTHeader, isJWTValid, 
+        PASSED, ACCESS_DENIED           // end state
+    }
+    
+    public enum FailureCode {
+        NONE,
+        BAD_SIGNATURE,
+        EXPIRED
+    }
+    
+    private enum ProcessState {
+        FIND_SOURCE,
+        VALIDATE,
+        COMPLETE
+    }
+    
+    private AuthenticationState processSources(Key key, String[] sources) {
+        AuthenticationState state = AuthenticationState.ACCESS_DENIED; // default
+        ProcessState process = ProcessState.FIND_SOURCE;
+        while (!process.equals(ProcessState.COMPLETE)) {
+            switch (process) {
+            case FIND_SOURCE :
+                //find the first non-empty source
+                for(int i = 0; i < sources.length && ((token == null) || token.isEmpty()); token = sources[i++]);
+                process = ((token == null) || token.isEmpty()) ? ProcessState.COMPLETE : ProcessState.VALIDATE;  
+                break;
+            case VALIDATE: // validate the jwt
+                boolean jwtValid = false;
+                try {
+                    jwt = Jwts.parser().setSigningKey(key).parseClaimsJws(token);
+                    jwtValid = true;
+                    code = FailureCode.NONE;
+                } catch (io.jsonwebtoken.SignatureException e) {
+                    // thrown if the signature on id_token cannot be verified.
+                    System.out.println("JWT did NOT validate ok, bad signature.");
+                    code = FailureCode.BAD_SIGNATURE;
+                } catch (ExpiredJwtException e) {
+                    // thrown if the jwt had expired.
+                    System.out.println("JWT did NOT validate ok, jwt had expired");
+                    code = FailureCode.EXPIRED;
+                }
+                state = !jwtValid ? AuthenticationState.ACCESS_DENIED : AuthenticationState.PASSED;
+                process = ProcessState.COMPLETE;
+                break;
+            default:
+                process = ProcessState.COMPLETE;
+                break;
+            }
+        }
+        return state;
+    }
+
+    public AuthenticationState getState() {
+        return state;
+    }
+
+    public FailureCode getCode() {
+        return code;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public Claims getClaims() {
+        return jwt.getBody();
+    }
+    
+    
+}

--- a/player-app/src/main/java/net/wasdev/gameon/player/Log.java
+++ b/player-app/src/main/java/net/wasdev/gameon/player/Log.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2015 IBM Corp.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *******************************************************************************/
+package net.wasdev.gameon.player;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Wrapper to provide a single logger with a consistent format that helps
+ * identify different endpoints in the messages
+ *
+ */
+public class Log {
+    private final static Logger log = Logger.getLogger("net.wasdev.gameon.player");
+    private static final String endpoint_log_format = "%-10s: %s";
+
+    public static void log(Level level, Object source, String message, Object... args) {
+        if (log.isLoggable(level)) {
+            String msg = String.format(endpoint_log_format, getHash(source), message);
+            log.log(useLevel(level), msg, args);
+        }
+    }
+
+    public static void log(Level level, Object source, String message, Throwable thrown) {
+        if (log.isLoggable(level)) {
+            String msg = String.format(endpoint_log_format, getHash(source), message);
+            log.log(useLevel(level), msg, thrown);
+        }
+    }
+
+    private static String getHash(Object source) {
+        return source == null ? "null" : Integer.toString(System.identityHashCode(source));
+    }
+
+    /**
+     * This bumps enabled trace up to INFO level, so it appears in messages.log
+     * @param level Original level
+     * @return Original Level or INFO level, whichever is greater
+     */
+    private static Level useLevel(Level level) {
+        if ( level.intValue() < Level.INFO.intValue() ) {
+            return Level.INFO;
+        }
+        return level;
+    }
+}

--- a/player-app/src/main/java/net/wasdev/gameon/player/PlayerFilter.java
+++ b/player-app/src/main/java/net/wasdev/gameon/player/PlayerFilter.java
@@ -95,7 +95,6 @@ public class PlayerFilter implements Filter {
         String playerId = null;
         Map<String, Object> claims = null;
         
-        System.out.println("==========> AUTHENTICATION");
         HttpServletRequest req = ((HttpServletRequest) request);
         JWT jwt = new JWT(signingCert, req.getHeader(jwtHeaderName));
         if(jwt.getState().equals(AuthenticationState.ACCESS_DENIED)) {

--- a/player-app/src/main/java/net/wasdev/gameon/player/PlayerFilter.java
+++ b/player-app/src/main/java/net/wasdev/gameon/player/PlayerFilter.java
@@ -106,13 +106,16 @@ public class PlayerFilter implements Filter {
                 return;
             }
         }
-        for(String param : req.getParameterValues(jwtParamName)) {
-            if(jwtParam == null) {
-                jwtParam = param;
-            } else {
-                //multiple header values are an error, so get a bad request
-                ((HttpServletResponse) response).sendError(HttpServletResponse.SC_BAD_REQUEST);
-                return;
+        String[] params = req.getParameterValues(jwtParamName);
+        if(params != null) {
+            for(String param : params) {
+                if(jwtParam == null) {
+                    jwtParam = param;
+                } else {
+                    //multiple header values are an error, so get a bad request
+                    ((HttpServletResponse) response).sendError(HttpServletResponse.SC_BAD_REQUEST);
+                    return;
+                }
             }
         }
         


### PR DESCRIPTION
This PR cannot be done in isolation, it needs the corresponding requests in map, mediator and webapp which are for the move_jwt_to_headers branch.

This request externalises the JWT (so that it can be shared/consistent) and moves any use of the jwt query param to a gameon-org HTTP header.