### PR TITLE
Update jacoco to tolerate newer java versions

### DIFF
--- a/player-app/build.gradle
+++ b/player-app/build.gradle
@@ -2,6 +2,10 @@ apply plugin: 'war'
 apply plugin: 'eclipse-wtp'
 apply plugin: 'jacoco'
 
+jacoco {
+  toolVersion = "0.8.4"
+}
+
 sourceCompatibility = 1.8
 
 configurations {


### PR DESCRIPTION
Older jacoco fails the build if built with jdk11 & up. 
Migrate build to use newer version to prevent this =)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-player/105)
<!-- Reviewable:end -->
