### PR TITLE
Ubi base image

### DIFF
--- a/player-app/src/test/java/org/gameontext/player/control/CertificateUtils.java
+++ b/player-app/src/test/java/org/gameontext/player/control/CertificateUtils.java
@@ -40,8 +40,8 @@ import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.MalformedJwtException;
 import io.jsonwebtoken.SignatureAlgorithm;
-import io.jsonwebtoken.SignatureException;
 import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.SecurityException;
 
 public class CertificateUtils {
 
@@ -50,64 +50,65 @@ public class CertificateUtils {
     //since the private key, and all credentials for it are in this
     //one file.
     //We ONLY use this key pair during unit test.
+
+    //expiry date 2030. 
+    // openssl req -nodes -new -x509  -keyout /tmp/key.pem -out /tmp/cert.pem -days 3650
+    // cat /tmp/cert.pem /tmp/key.pem /tmp/cert.txt
+    //then import /tmp/cert.txt into certString as below.
+
     final static String certString =
-            "Bag Attributes\n"+
-                    "    localKeyID: 31 34 35 36 39 32 38 39 39 31 35 35 30 \n"+
-                    "    friendlyName: default\n"+
-                    "Key Attributes: <No Attributes>\n"+
-                    "-----BEGIN PRIVATE KEY-----\n"+
-                    "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQC2IJ0THYPvm669\n"+
-                    "AuyCHP8GUmQB0r9MeW1sFQIRWdkQRijNIKa60sqN58b7S11Mc8ch+CXQ3bMZM4CR\n"+
-                    "qX8GAc/0Gd/kkQhen7Q8JGnM+AzV51vqgaYV4A3A2i/ruToZpUD2VCl4nozhoqjw\n"+
-                    "AzPivRBwzCi44dR2AnFAfEEH8dPvizP11nuS5fCBMQy8uhm2Y4JXg1uW0szDkbj5\n"+
-                    "E6r3JKKs79d0iDfWNogmCXxs95fFyx3avU/n7X7uYku0QXpmuXtNjOe+92Sq7kq/\n"+
-                    "0BWmJFfhks2GJi7ea0MIKd4AxiYuJCQahLx9L8DLdxlD5qV42YKPog1n3ETYCpIX\n"+
-                    "q3MZ++5tAgMBAAECggEAUfgruca28shmxLrkJ0tVnErIp+lqH8km7lYmMBj4ENMC\n"+
-                    "2g+v+rWUZHnEnKU2wIn7Pdapbm/Zg6YiX2yhttpp9bsPgZek5LGMNOVOmOmrHTqb\n"+
-                    "q9feIEpO5lVM7BLZi2FM85C9eYQidAr5bcyDNbFSDPJWAZ/iN5qxzgweWK0GbfC8\n"+
-                    "4GlzJHJz3Jj/7y2s2n22vxYvqKPfDI3hWNQcr6tXs8QxHtUX1xl0JKQU62itUMI1\n"+
-                    "vWgeiMQ56rxBi9w+h3YBRVFgxOjNsPncEesNe0IlHXWEWu2GSopYoHVck08iezxK\n"+
-                    "q8ULPfPcJR5IUsUQQM0F1NSgWi8VD5BBMJfIlsVOIQKBgQD1jkFkSLHdsvj7DwrB\n"+
-                    "RoTElRQ8nNTI1/Pw9URm+29vx+rPybu9Rm+kCJKCkoZqH275Fa6/ZWWF6vGGmtsA\n"+
-                    "EosHlzz+cf7uV2eig8bpvO35jvX9cmIvj4krcHM/JdSveyHm3tvXXEraUiBKkZxm\n"+
-                    "LH/Y0OPvkO4cMPWXTpUhafZ/AwKBgQC937dcL4/chF6Qq42iqNo3pHcvppKJFuZb\n"+
-                    "bsI706UGviw3noZLGjci5jGrDRRoy182M2ec7kR13P2LDVaOkjcf8msTh+fYWbWe\n"+
-                    "nrU7aMOpYiSJ8iTGyfuL8DBLCyrD42oPVlMVkRsb/5oKeCCzM2DB0oJ/eQ/FYAF2\n"+
-                    "Xn+1VjFpzwKBgQClL7BPvRNiF36krWbHxB+Wes8lQz9laNjidKwyNtytLqiIZaYU\n"+
-                    "2uhJSbb9fYJMq56kk3B9ssFMCFO4AD5o2xCJ57SRWrBrN4Mw8UMDhCP2qLRUbfkd\n"+
-                    "E4rsHPZ6OYHNFqEkxTDQvHZiTbMJVtEGbtMGUOe1BiMX9duQkL2Dv9uhbwKBgAG0\n"+
-                    "HCULmDLWTTLnFyI6eZq+MwOObwoj1nVDjSKUR4rD8gmdtn6+AXiisBdkyqYWDQij\n"+
-                    "dW6HBL45+VxiBkDJNw1mU2eddIsQYvzFV8LssbS3WLSUI5hU/5jF0ukZdIzFYZI5\n"+
-                    "qA0tfBzIMk2dvk1dTKTwipMyNt4CeoDhYCv0VgUpAoGAMtoOF+t6iRDpNpjq4tCH\n"+
-                    "2sdfqOnjGIeLQ5ciJoT5Xryz/Ww9yt8YWDXr5hZOPEMeNONtWXk5WxafsVLJ0LZf\n"+
-                    "ko8KiqP6058lxHHtiJadIUyAVX4KpLmojEMH20EXW3mvxRf9ch4ITkHa9AGkW+Hl\n"+
-                    "qAI9LIpl9U2dsMskXaAc8NM=\n"+
-                    "-----END PRIVATE KEY-----\n"+
-                    "Bag Attributes\n"+
-                    "    localKeyID: 31 34 35 36 39 32 38 39 39 31 35 35 30 \n"+
-                    "    friendlyName: default\n"+
-                    "subject=/C=CA/ST=Test/L=Test/O=Test/OU=Test/CN=Test\n"+
-                    "issuer=/C=CA/ST=Test/L=Test/O=Test/OU=Test/CN=Test\n"+
-                    "-----BEGIN CERTIFICATE-----\n"+
-                    "MIIDUTCCAjmgAwIBAgIEd+noizANBgkqhkiG9w0BAQUFADBYMQswCQYDVQQGEwJD\n"+
-                    "QTENMAsGA1UECBMEVGVzdDENMAsGA1UEBxMEVGVzdDENMAsGA1UEChMEVGVzdDEN\n"+
-                    "MAsGA1UECxMEVGVzdDENMAsGA1UEAxMEVGVzdDAgFw0xNjAzMDIxNDI5MjRaGA8\nY"+
-                    "MTE2MDIwNzE0MjkyNFowWDELMAkGA1UEBhMCQ0ExDTALBgNVBAgTBFRlc3QxDTAL\n"+
-                    "BgNVBAcTBFRlc3QxDTALBgNVBAoTBFRlc3QxDTALBgNVBAsTBFRlc3QxDTALBgNV\n"+
-                    "BAMTBFRlc3QwggEiMA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQC2IJ0THYPv\n"+
-                    "m669AuyCHP8GUmQB0r9MeW1sFQIRWdkQRijNIKa60sqN58b7S11Mc8ch+CXQ3bMZ\n"+
-                    "M4CRqX8GAc/0Gd/kkQhen7Q8JGnM+AzV51vqgaYV4A3A2i/ruToZpUD2VCl4nozh\n"+
-                    "oqjwAzPivRBwzCi44dR2AnFAfEEH8dPvizP11nuS5fCBMQy8uhm2Y4JXg1uW0szD\n"+
-                    "kbj5E6r3JKKs79d0iDfWNogmCXxs95fFyx3avU/n7X7uYku0QXpmuXtNjOe+92Sq\n"+
-                    "7kq/0BWmJFfhks2GJi7ea0MIKd4AxiYuJCQahLx9L8DLdxlD5qV42YKPog1n3ET\nY"+
-                    "CpIXq3MZ++5tAgMBAAGjITAfMB0GA1UdDgQWBBQbKbM4oe9VhqO6xs2pPi0DuDdT\n"+
-                    "2DANBgkqhkiG9w0BAQUFAAOCAQEAtUnEyi1ZZJq0hn0KJc//G60Wj6RY9ZqRYLx6\n"+
-                    "UHq7Od/B6z4Nc44eMVXETTWaU2Jw+zJLHycNzVJjKYamkrGAU3nrXljZiiXYrDfa\n"+
-                    "i88m6+T6sSN97sbOzBUEOUKWwScE0VIpNxjmdp4CtQHC4GRZ7hwFjtwYt3ocFfE4\n"+
-                    "3YZ6z75kNipVgwne9SwWff0Fj2L/5h2TKm9yxcOGKBayGY663fUeDPmNLscMoqkf\n"+
-                    "pzYnTJ+amsLvGoeTl4SzDpMx7xbJn/JzgrG2udCA8+nRdQtflcmW2HP5yxNKuLsp\n"+
-                    "ejtMxJUwPDsxA41ug2efaCC9dSlZIa3VSibZjjmUD5EcHCO4NA==\n"+
-                    "-----END CERTIFICATE-----\n";
+    "-----BEGIN CERTIFICATE-----\n"+
+    "MIIDzTCCArWgAwIBAgIUShhlFeADqKApkwv7f40HvqJ3w0kwDQYJKoZIhvcNAQEL\n"+
+    "BQAwdjELMAkGA1UEBhMCVFQxDTALBgNVBAgMBFRlc3QxDTALBgNVBAcMBFRlc3Qx\n"+
+    "DTALBgNVBAoMBFRlc3QxDTALBgNVBAsMBFRlc3QxDTALBgNVBAMMBFRlc3QxHDAa\n"+
+    "BgkqhkiG9w0BCQEWDXRlc3RAdGVzdC5jb20wHhcNMjAwOTA4MTg1MDM2WhcNMzAw\n"+
+    "OTA2MTg1MDM2WjB2MQswCQYDVQQGEwJUVDENMAsGA1UECAwEVGVzdDENMAsGA1UE\n"+
+    "BwwEVGVzdDENMAsGA1UECgwEVGVzdDENMAsGA1UECwwEVGVzdDENMAsGA1UEAwwE\n"+
+    "VGVzdDEcMBoGCSqGSIb3DQEJARYNdGVzdEB0ZXN0LmNvbTCCASIwDQYJKoZIhvcN\n"+
+    "AQEBBQADggEPADCCAQoCggEBAMbMxnWtFPm8LTX6BAQoXn8IOW4tvJIK/yRUQ8MJ\n"+
+    "rQUIpeyU0F4Xb0QWU6g/hA0d1v/ccfCNaimvl8xFblwzJif+u36dv+qDQhmJewjy\n"+
+    "91m+NvMU7u3SjUnyyxabALtAXNSaxWX9j4HNTvLaeVwNVB8L5otWeVJ27PMlVwkG\n"+
+    "6Ji9DK9iadzOROBQ1tYQb5KLKbzc2GzitCi+MPNWRxwxM4H6FRbxLmGZA/QOvT9n\n"+
+    "x6HwTtOOCUGEy/zNXmnV9RmNog/ZQgQFOcDF8OWoP1U+JcciSMm5cS4ql5jyunpD\n"+
+    "uW82/kdfyRTa2POcujAqy/fx4T9lLbz18a8S3qZtC+Q56wECAwEAAaNTMFEwHQYD\n"+
+    "VR0OBBYEFNYSxWdJGqPtxyMQjdFt+fB1szlLMB8GA1UdIwQYMBaAFNYSxWdJGqPt\n"+
+    "xyMQjdFt+fB1szlLMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEB\n"+
+    "AIJ9KYDoQYa1LjuD1GPQg8YYVO8sg/4GNe0BEThYzmwenbQVaeAZP+cToHshfncD\n"+
+    "hBDYu9NmoES0SA9tcBOLzkAyDuLrMT8C4rtfJGtvHRsGzNoRJuS99xdquY9omkdT\n"+
+    "F38Fj24vmrFOMMCWY84STEcbyJR5hLI/j2gxeVWjNza69VOyE4wNE2OuT5qMFR7n\n"+
+    "AERU/jfO6x6Kr7La9uWZk9m63UJGKL3f78LVS5YOHRyKlbXD3AI8fKGj6a4Mm3dm\n"+
+    "9raECpjvMPoyDt6kIW2R8m/Moz/xqHxpMRStpEm1HXabyhfxAsAxASnuncG0+O+m\n"+
+    "zbl7nc0HclgHyMY2Ou7j05c=\n"+
+    "-----END CERTIFICATE-----\n"+
+    "-----BEGIN PRIVATE KEY-----\n"+
+    "MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDGzMZ1rRT5vC01\n"+
+    "+gQEKF5/CDluLbySCv8kVEPDCa0FCKXslNBeF29EFlOoP4QNHdb/3HHwjWopr5fM\n"+
+    "RW5cMyYn/rt+nb/qg0IZiXsI8vdZvjbzFO7t0o1J8ssWmwC7QFzUmsVl/Y+BzU7y\n"+
+    "2nlcDVQfC+aLVnlSduzzJVcJBuiYvQyvYmnczkTgUNbWEG+Siym83Nhs4rQovjDz\n"+
+    "VkccMTOB+hUW8S5hmQP0Dr0/Z8eh8E7TjglBhMv8zV5p1fUZjaIP2UIEBTnAxfDl\n"+
+    "qD9VPiXHIkjJuXEuKpeY8rp6Q7lvNv5HX8kU2tjznLowKsv38eE/ZS289fGvEt6m\n"+
+    "bQvkOesBAgMBAAECggEAPyDJqJaUwZTy2mARJGzZTQeEjSsy5UFesd+cQPPyoFWV\n"+
+    "suGypR5V884PNK8utKeUHV2YROXzH1emIXSuzdJkPHEUgul/Bu41cDyK+FWHHFVd\n"+
+    "x6UPFjA1M5VIzl3cRpnyoIShSHjTOEnE1zNvND77RnyV8gs8rWYcaj2iPLiX5eAb\n"+
+    "Mff/mfcZYeVNmIB87XZ0CwoxvkgtbMzxkB8KVU5wHLH19gitg8/AmnQyzTmi5+nj\n"+
+    "uRwfi0cr3ecP5D/C4bnSTBdgLJ1QTtAglYBeNJx/zdeJ/HW6Bp8gYddQpzYU5ZzT\n"+
+    "vIXwx0WlCUZk3UMfOrPgTZqtoVqp2qfm3Y+YTw5tAQKBgQDn1wZNrac7pE2qhnBB\n"+
+    "EfqVAaETH9tYxVXti4T2z6v/nFczvLoWvUyhDOg9hOTf0NMlUlz585CaFqtOzMCL\n"+
+    "xOJYXOaPMavtTka4pswJEqhmp4RujYa24p5gLcDqdfYz/G1bUFAEKRse2gwCD3ZB\n"+
+    "IQsA+t8xZGQzM2HDJ7fdsG3wUQKBgQDbhFDSqRK/RHeZCAT8Dj7CcuZK3H+azRta\n"+
+    "EEM93hIetnXWaq27BSeWoHuFh43wJnlwE5otfJdYAdLq7Xnl8rTCb61Hl6Q9CEVW\n"+
+    "djp6xAJl2X7hVTwO728/RGzKac2cudrg6NhsJyVqxT9oHN4Qqo4GRb3OPaBIEWme\n"+
+    "aSmmU+TTsQKBgCTwY7a4tm6QTTegV/5mKPDY45sydjZ8qqZAlpzkldkSReqeZV/+\n"+
+    "JVl7vv0eUYE/uoS1zM6eeimy9vSFNyCN7Cp8Etg559TVpfsByHyhlmdUxYr/zbkR\n"+
+    "/n4AjD5PMT0zORFViIpBKmsN/t/NKuBRrXkof6tU/YoS476+c1NFKx8hAoGBAK7r\n"+
+    "5fen8J9nMKJKKKatt0b9hhM7V5eEP3pqIRronanJnWbJxTyVI/G8WhGSbgFitzwe\n"+
+    "8qmycWsYsPixWYRp/a4+jWbSKHbV42K9fWYcUQjV4mwunlgMZaqVnNdCrixoUUkN\n"+
+    "Yn/0RbWqDhepgS7oqZnH8zKoGtOyxGYNyLmYemxRAoGAWnMjrT8ed61eENbbvuvF\n"+
+    "Npmmn12sLHiQMuJEq55NFl9pq1cGaSMcv4qLp7sBCCxZNEVimNalO7S+yHerO6Sy\n"+
+    "9UF/7D0sue2XjVNohWx1iYXh8zzM5Cr6pYCz7ruwgWYf2hqt+r89IWbVC0Oo5/1c\n"+
+    "/WPOpptTLN9aIjDKues3V2I=\n"+
+    "-----END PRIVATE KEY-----\n"+
+    "\n";
 
     /**
      * Since the cert data above is final, we're safe to cache the Cert once we build it
@@ -161,11 +162,11 @@ public class CertificateUtils {
     }
 
     @Test
-    public void testJwt() throws NoSuchAlgorithmException, InvalidKeySpecException, IOException, ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SignatureException, IllegalArgumentException, CertificateException {
+    public void testJwt() throws NoSuchAlgorithmException, InvalidKeySpecException, IOException, ExpiredJwtException, UnsupportedJwtException, MalformedJwtException, SecurityException, IllegalArgumentException, CertificateException {
         Claims testClaims = Jwts.claims();
         testClaims.put("aud", "test");
         String newJwt = Jwts.builder().setHeaderParam("kid", "test").setClaims(testClaims)
-                .signWith(SignatureAlgorithm.RS256, getKey()).compact();
+                .signWith(getKey(), SignatureAlgorithm.RS256).compact();
         assertNotNull("could not build jwt using test certificate",newJwt);
         Jws<Claims> jwt = Jwts.parser().setSigningKey(getCertificate().getPublicKey()).parseClaimsJws(newJwt);
         assertNotNull("could not decode jwt using test certificate",jwt);

--- a/player-wlpcfg/Dockerfile
+++ b/player-wlpcfg/Dockerfile
@@ -3,7 +3,9 @@ FROM gameontext/docker-liberty-custom:master-29
 ENV SERVERDIRNAME player
 
 ADD https://raw.githubusercontent.com/gameontext/gameon/master/bin/init_couchdb.sh /opt/init_couchdb.sh
+USER 0
 RUN chmod g+rwx /opt/init_couchdb.sh
+USER 1001
 COPY ./startup.sh /opt/startup.sh
 COPY ./servers/gameon-player /opt/ol/wlp/usr/servers/defaultServer/
 

--- a/player-wlpcfg/Dockerfile
+++ b/player-wlpcfg/Dockerfile
@@ -1,8 +1,9 @@
-FROM gameontext/docker-liberty-custom:master-14
+FROM default-route-openshift-image-registry.apps-crc.testing/gameon-system/docker-liberty-custom:master-oz1
 
 ENV SERVERDIRNAME player
 
 ADD https://raw.githubusercontent.com/gameontext/gameon/master/bin/init_couchdb.sh /opt/init_couchdb.sh
+RUN chmod g+rwx /opt/init_couchdb.sh
 COPY ./startup.sh /opt/startup.sh
 COPY ./servers/gameon-player /opt/ol/wlp/usr/servers/defaultServer/
 

--- a/player-wlpcfg/Dockerfile
+++ b/player-wlpcfg/Dockerfile
@@ -1,4 +1,4 @@
-FROM default-route-openshift-image-registry.apps-crc.testing/gameon-system/docker-liberty-custom:master-oz1
+FROM gameontext/docker-liberty-custom:master-29
 
 ENV SERVERDIRNAME player
 


### PR DESCRIPTION
UBI Change is simple enough, move to the new docker liberty base image (now ubi as of build 29), and also remember to add permission to the couch db init script to allow non-root users (but in root group) to invoke it (as when on openshift). 

The test change is .. odd. 

Apparently somehow the cert data we haven't changed in forever is now considered invalid. I'd like to say how, except all it will tell me is the date format for the cert expiry was incorrect. In this assessment, both Java and the openssl commandline tool agreed. 

Rather than debug further I regenerated the cert & key using current openssl commandline tool, and updated the test suite code to use it. Also moved it off some deprecated jwt api usage while I was there, and added a comment re how to regen the cert if we're still looking at this in 10 years time.

Minikube/Docker need testing before this goes non-draft

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gameontext/gameon-player/106)
<!-- Reviewable:end -->
